### PR TITLE
Hw08 envdir tool

### DIFF
--- a/hw08_envdir_tool/env_reader.go
+++ b/hw08_envdir_tool/env_reader.go
@@ -1,5 +1,15 @@
 package main
 
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 type Environment map[string]EnvValue
 
 // EnvValue helps to distinguish between empty files and files with the first empty line.
@@ -11,6 +21,44 @@ type EnvValue struct {
 // ReadDir reads a specified directory and returns map of env variables.
 // Variables represented as files where filename is name of variable, file first line is a value.
 func ReadDir(dir string) (Environment, error) {
-	// Place your code here
-	return nil, nil
+	var (
+		invalidSymbol = "="
+	)
+	environments := make(Environment)
+
+	dirEntry, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, de := range dirEntry {
+		if de.IsDir() || !de.Mode().IsRegular() || strings.Contains(de.Name(), invalidSymbol) {
+			continue
+		}
+		f, err := os.OpenFile(filepath.Join(dir, de.Name()), os.O_RDONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		reader := bufio.NewReader(f)
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
+		}
+		firstLine := strings.TrimRight(string(bytes.Replace(line, []byte{0x00}, []byte{'\n'}, -1)), "\t ")
+
+		eVal := EnvValue{
+			Value:      firstLine,
+			NeedRemove: false,
+		}
+		if firstLine == "" {
+			eVal.NeedRemove = true
+		}
+		environments[de.Name()] = eVal
+	}
+
+	return environments, nil
 }

--- a/hw08_envdir_tool/env_reader.go
+++ b/hw08_envdir_tool/env_reader.go
@@ -13,6 +13,12 @@ import (
 
 type Environment map[string]EnvValue
 
+func (env Environment) Clear() {
+	for k := range env {
+		delete(env, k)
+	}
+}
+
 // EnvValue helps to distinguish between empty files and files with the first empty line.
 type EnvValue struct {
 	Value      string

--- a/hw08_envdir_tool/env_reader_test.go
+++ b/hw08_envdir_tool/env_reader_test.go
@@ -24,4 +24,27 @@ func TestReadDir(t *testing.T) {
 		require.NotNil(t, err)
 		require.Nil(t, env)
 	})
+
+	t.Run("invalid symbol", func(t *testing.T) {
+		dir, err := os.Getwd()
+		require.Nil(t, err)
+		pathTemp, err := os.MkdirTemp(dir, "test_invalid_symbol")
+		require.Nil(t, err)
+		tempFileName := "INVALID=FILE"
+		expectedEnvLen := 0
+		file, err := os.CreateTemp(pathTemp, tempFileName)
+		require.Nil(t, err)
+		f, err := os.Stat(file.Name())
+		require.Nil(t, err)
+		require.Contains(t, f.Name(), tempFileName)
+		env, err := ReadDir(pathTemp)
+		require.Nil(t, err)
+		require.Equal(t, expectedEnvLen, len(env))
+		err = file.Close()
+		require.Nil(t, err)
+		err = os.Remove(file.Name())
+		require.Nil(t, err)
+		err = os.RemoveAll(pathTemp)
+		require.Nil(t, err)
+	})
 }

--- a/hw08_envdir_tool/env_reader_test.go
+++ b/hw08_envdir_tool/env_reader_test.go
@@ -1,7 +1,27 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestReadDir(t *testing.T) {
-	// Place your code here
+	t.Run("simple test", func(t *testing.T) {
+		expectedLen := 5
+		dir, err := os.Getwd()
+		require.Nil(t, err)
+		dirPath := filepath.Join(dir, "/testdata/env")
+		env, err := ReadDir(dirPath)
+		require.Nil(t, err)
+		require.Equal(t, expectedLen, len(env))
+	})
+
+	t.Run("invalid dir", func(t *testing.T) {
+		env, err := ReadDir("")
+		require.NotNil(t, err)
+		require.Nil(t, env)
+	})
 }

--- a/hw08_envdir_tool/executor.go
+++ b/hw08_envdir_tool/executor.go
@@ -33,6 +33,7 @@ func RunCmd(cmd []string, env Environment) (returnCode int) {
 		if errors.As(err, &errExitCode) {
 			return errExitCode.ExitCode()
 		}
+		return 1
 	}
 
 	return

--- a/hw08_envdir_tool/executor.go
+++ b/hw08_envdir_tool/executor.go
@@ -1,7 +1,34 @@
 package main
 
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
 // RunCmd runs a command + arguments (cmd) with environment variables from env.
 func RunCmd(cmd []string, env Environment) (returnCode int) {
-	// Place your code here.
+	for eVar, eVal := range env {
+		if eVal.NeedRemove {
+			os.Unsetenv(eVar)
+			continue
+		}
+		os.Setenv(eVar, eVal.Value)
+	}
+	proc := exec.Command(cmd[0], cmd[1:]...)
+	setSTD(proc, os.Stdout, os.Stderr, os.Stdin)
+
+	if err := proc.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode()
+		}
+	}
+
 	return
+}
+
+func setSTD(proc *exec.Cmd, out io.Writer, err io.Writer, rd io.Reader) {
+	proc.Stdout = out
+	proc.Stderr = err
+	proc.Stdin = rd
 }

--- a/hw08_envdir_tool/executor_test.go
+++ b/hw08_envdir_tool/executor_test.go
@@ -1,7 +1,78 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestRunCmd(t *testing.T) {
-	// Place your code here
+	env := make(Environment)
+
+	dir, err := os.Getwd()
+	require.Nil(t, err)
+	testCmd := []string{}
+	switch runtime.GOOS {
+	case "windows":
+		testCmd = []string{"bash", filepath.Join(dir, "/testdata/echo.sh"), "arg1=1", "arg2=2"}
+	case "linux":
+		testCmd = []string{filepath.Join(dir, "/testdata/echo.sh"), "arg1=1", "arg2=2"}
+	}
+
+	t.Run("simple test", func(t *testing.T) {
+		env.Clear()
+		expectedCode := 0
+		cmdCode := RunCmd(testCmd, env)
+		require.Equal(t, expectedCode, cmdCode)
+	})
+
+	t.Run("test on bash", func(t *testing.T) {
+		env.Clear()
+		expectedCode := 127
+		fmt.Printf("expectedCode: %v\n", expectedCode)
+		testCmd := []string{"/bin/bash", "xxx"}
+		cmdCode := RunCmd(testCmd, env)
+		require.Equal(t, expectedCode, cmdCode)
+	})
+
+	t.Run("test on error 'ErrEmptyCmd'", func(t *testing.T) {
+		env.Clear()
+		expectedCode := 1
+		testCmd := make([]string, 0)
+		cmdCode := RunCmd(testCmd, env)
+		require.Equal(t, expectedCode, cmdCode)
+	})
+
+	t.Run("test on set environment", func(t *testing.T) {
+		env.Clear()
+		expectedCode := 0
+		envName := "TEST_ENV_NAME"
+		envValue := "TEST_ENV_VALUE"
+		env[envName] = EnvValue{envValue, false}
+		cmdCode := RunCmd(testCmd, env)
+		require.Equal(t, expectedCode, cmdCode)
+		val, ok := os.LookupEnv(envName)
+		require.True(t, ok)
+		require.Equal(t, val, envValue)
+	})
+
+	t.Run("test on unset environment", func(t *testing.T) {
+		env.Clear()
+		expectedCode := 0
+		envName := "TEST_ENV_NAME"
+		envValueForUnset := "TEST_ENV_VALUE"
+		envValue := ""
+		err := os.Setenv(envName, envValueForUnset)
+		require.Nil(t, err)
+		env[envName] = EnvValue{envValue, true}
+		cmdCode := RunCmd(testCmd, env)
+		require.Equal(t, expectedCode, cmdCode)
+		val, ok := os.LookupEnv(envName)
+		require.False(t, ok)
+		require.Equal(t, val, envValue)
+	})
 }

--- a/hw08_envdir_tool/go.mod
+++ b/hw08_envdir_tool/go.mod
@@ -1,3 +1,11 @@
-module github.com/fixme_my_friend/hw08_envdir_tool
+module github.com/Galiks/OTUS_2022/hw08_envdir_tool
 
-go 1.16
+go 1.18
+
+require github.com/stretchr/testify v1.8.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/hw08_envdir_tool/go.sum
+++ b/hw08_envdir_tool/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hw08_envdir_tool/main.go
+++ b/hw08_envdir_tool/main.go
@@ -1,5 +1,27 @@
 package main
 
+import (
+	"errors"
+	"log"
+	"os"
+)
+
+var (
+	ErrCountArgs = errors.New("error count args")
+)
+
 func main() {
-	// Place your code here.
+	if len(os.Args) < 3 {
+		log.Fatal(ErrCountArgs)
+	}
+
+	pathToDir := os.Args[1]
+	comand := os.Args[2:]
+
+	dir, err := ReadDir(pathToDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(RunCmd(comand, dir))
 }

--- a/hw08_envdir_tool/main.go
+++ b/hw08_envdir_tool/main.go
@@ -6,9 +6,7 @@ import (
 	"os"
 )
 
-var (
-	ErrCountArgs = errors.New("error count args")
-)
+var ErrCountArgs = errors.New("error count args")
 
 func main() {
 	if len(os.Args) < 3 {


### PR DESCRIPTION
## Домашнее задание №8 «Утилита envdir»

Необходимо реализовать утилиту `envdir` на Go.

Эта утилита позволяет запускать программы, получая переменные окружения из определенной директории:
- если директория содержит файл с именем `S`, первой строкой которого является `T`, то
`envdir` удаляет переменную среды с именем `S`, если таковая существует, а затем добавляет
переменную среды с именем `S` и значением `T`;
- имя `S` не должно содержать `=`; пробелы и табуляция в конце `T` удаляются; терминальные нули (`0x00`) заменяются на перевод строки (`\n`);
- если файл полностью пустой (длина - 0 байт), то `envdir` удаляет переменную окружения с именем `S`.

---
Пример использования:
```bash
$ go-envdir /path/to/env/dir command arg1 arg2
```
Если в директории `/path/to/env/dir` содержатся файлы:
* `FOO` с содержимым `123`;
* `BAR` с содержимым `value`,

то вызов выше эквивалентен вызову
```bash
$ FOO=123 BAR=value command arg1 arg2
```
---

Также необходимо, чтобы:
* стандартные потоки ввода/вывода/ошибок пробрасывались в вызываемую программу;
* код выхода утилиты совпадал с кодом выхода программы.

При необходимости можно выделять дополнительные функции / ошибки.

Юнит-тесты могут использовать файлы из `testdata` или создавать свои директории / файлы,
которые **обязаны** подчищать после своего выполнения.

### Критерии оценки
- Пайплайн зелёный - 4 балла
- Добавлены юнит-тесты - до 4 баллов
- Понятность и чистота кода - до 2 баллов

#### Зачёт от 7 баллов

### Подсказки
- https://www.unix.com/man-page/debian/8/envdir/
- `os.Args`
- `ioutil.ReadDir`
- `bytes.Replace`, `strings.TrimRight`
- `exec.Command`
