### PR TITLE
Hw09 struct validator

### DIFF
--- a/hw09_struct_validator/go.mod
+++ b/hw09_struct_validator/go.mod
@@ -1,3 +1,5 @@
 module github.com/fixme_my_friend/hw09_struct_validator
 
 go 1.16
+
+require github.com/stretchr/testify v1.8.0

--- a/hw09_struct_validator/go.sum
+++ b/hw09_struct_validator/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -113,7 +113,7 @@ func Validate(v interface{}) error {
 				lock.Unlock()
 			case reflect.Array, reflect.Bool, reflect.Chan, reflect.Complex128, reflect.Complex64,
 				reflect.Float32, reflect.Float64, reflect.Func, reflect.Interface, reflect.Invalid,
-				reflect.Map, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Map, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Ptr,
 				reflect.Uint8, reflect.Uintptr, reflect.UnsafePointer:
 			default:
 				return

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -1,5 +1,48 @@
 package hw09structvalidator
 
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type validateHandlerFunc func(key string, value string, fieldName string, field interface{}) error
+
+type stringValidator string
+
+var (
+	length       stringValidator = "len"
+	regexpString stringValidator = "regexp"
+	subsetString stringValidator = "in"
+)
+
+type numberValidator string
+
+var (
+	minimum      numberValidator = "min"
+	maximum      numberValidator = "max"
+	subsetNumber numberValidator = "in"
+)
+
+var (
+	ErrInterfaceType       = errors.New("interface is not struct")
+	ErrInterfaceConversion = errors.New("invalid type for conversion")
+
+	ErrInvalidEmptyTag = errors.New("invalid tag: tag can't be empty")
+
+	ErrStringLength = errors.New("length of string not equals number in tag")
+	ErrStringRegexp = errors.New("string not equals regexp in tag")
+	ErrStringIn     = errors.New("string is not contains in subset of tag")
+
+	ErrNumberMax = errors.New("number is bigger than max")
+	ErrNumberMin = errors.New("number is less than min")
+	ErrNumberIn  = errors.New("number is not contains in subset of tag")
+)
+
 type ValidationError struct {
 	Field string
 	Err   error
@@ -8,10 +51,271 @@ type ValidationError struct {
 type ValidationErrors []ValidationError
 
 func (v ValidationErrors) Error() string {
-	panic("implement me")
+	errorString := strings.Builder{}
+	for _, err := range v {
+		errorString.WriteString(fmt.Sprintf("Field: %s - Error: %v\n", err.Field, err.Err))
+	}
+	return errorString.String()
 }
 
 func Validate(v interface{}) error {
-	// Place your code here.
-	return nil
+	var (
+		validateTagName                   = "validate"
+		validationErrors ValidationErrors = nil
+		wg               sync.WaitGroup
+		lock             sync.Mutex
+	)
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Struct {
+		validationErrors = append(validationErrors, ValidationError{
+			Field: val.Type().Name(),
+			Err:   ErrInterfaceType,
+		})
+		return validationErrors
+	}
+	for i := 0; i < val.NumField(); i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			field := val.Type().Field(i)
+			tag, ok := field.Tag.Lookup(validateTagName)
+			if !ok {
+				return
+			}
+			switch field.Type.Kind() {
+			case reflect.String:
+				fieldVal := val.Field(i).String()
+				if err := validateHandler(fieldVal, tag, field.Name, validateString); err != nil {
+					lock.Lock()
+					validationErrors = errHandler(err, validationErrors, field.Name)
+					lock.Unlock()
+				}
+			case reflect.Int:
+				fieldVal := val.Field(i).Int()
+				if err := validateHandler(fieldVal, tag, field.Name, validateNumber); err != nil {
+					lock.Lock()
+					validationErrors = errHandler(err, validationErrors, field.Name)
+					lock.Unlock()
+				}
+			case reflect.Slice:
+				fieldVal := val.Field(i).Interface()
+				if err := validateHandler(fieldVal, tag, field.Name, validateSlice); err != nil {
+					lock.Lock()
+					validationErrors = errHandler(err, validationErrors, field.Name)
+					lock.Unlock()
+				}
+			case reflect.Struct:
+				fieldVal := val.Field(i).Interface()
+				err := Validate(fieldVal)
+				lock.Lock()
+				validationErrors = errHandler(err, validationErrors, field.Name)
+				lock.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return validationErrors
+}
+
+// личная моля болячка. Не люблю повторение функционала
+func errHandler(err error, validationErrors ValidationErrors, fieldName string) ValidationErrors {
+	var valErr ValidationErrors
+	if errors.As(err, &valErr) {
+		validationErrors = append(validationErrors, valErr...)
+	} else {
+		validationErrors = append(validationErrors, ValidationError{
+			Field: fieldName,
+			Err:   err,
+		})
+	}
+	return validationErrors
+}
+
+func validateHandler(field interface{}, fullCondition, fieldName string, validateHandler validateHandlerFunc) error {
+	var (
+		conditionsSeparator = "|"
+		valErrors           = make(ValidationErrors, 0)
+	)
+	if fullCondition == "" || field == nil {
+		return nil
+	}
+	conditions := strings.Split(fullCondition, conditionsSeparator)
+	for _, cond := range conditions {
+		key, value, err := getValidationPair(cond)
+		if err != nil {
+			valErrors = append(valErrors, ValidationError{
+				Field: fieldName,
+				Err:   err,
+			})
+			continue
+		}
+		if err = validateHandler(key, value, fieldName, field); err != nil {
+			valErrors = errHandler(err, valErrors, fieldName)
+		}
+	}
+	return valErrors
+}
+
+func validateString(key, value, fieldName string, field interface{}) error {
+	var errors ValidationErrors
+	str, ok := field.(string)
+	if !ok {
+		errors = append(errors, ValidationError{
+			Field: fieldName,
+			Err:   ErrInterfaceConversion,
+		})
+		return errors
+	}
+
+	switch key {
+	case string(length):
+		lengthNumber, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   err,
+			})
+			return errors
+		}
+
+		if len(str) != int(lengthNumber) {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrStringLength,
+			})
+		}
+	case string(regexpString):
+		reg, err := regexp.Compile(value)
+		if err != nil {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   err,
+			})
+		}
+		if !reg.MatchString(str) {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrStringRegexp,
+			})
+		}
+	case string(subsetString):
+		if !strings.Contains(value, str) {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrStringIn,
+			})
+		}
+	}
+	return errors
+}
+
+func validateNumber(key, value, fieldName string, field interface{}) error {
+	var errors ValidationErrors
+	number, ok := field.(int64)
+	if !ok {
+		errors = append(errors, ValidationError{
+			Field: fieldName,
+			Err:   ErrInterfaceConversion,
+		})
+		return errors
+	}
+
+	switch key {
+	case string(maximum):
+		max, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   err,
+			})
+			return errors
+		}
+		if number > max {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrNumberMax,
+			})
+		}
+	case string(minimum):
+		min, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   err,
+			})
+			return errors
+		}
+		if int64(number) < min {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrNumberMin,
+			})
+		}
+	case string(subsetNumber):
+		if !strings.Contains(value, strconv.Itoa(int(number))) {
+			errors = append(errors, ValidationError{
+				Field: fieldName,
+				Err:   ErrNumberIn,
+			})
+		}
+	}
+	return errors
+}
+
+func validateSlice(key, value, fieldName string, field interface{}) error {
+	var validateErrors ValidationErrors
+	switch field := field.(type) {
+	case []int64:
+		for _, elem := range field {
+			err := validateNumber(key, value, fieldName, elem)
+			var valErr ValidationErrors
+			if errors.As(err, &valErr) {
+				validateErrors = append(validateErrors, valErr...)
+			} else {
+				valErr = append(valErr, ValidationError{
+					Field: fieldName,
+					Err:   err,
+				})
+			}
+
+		}
+	case []string:
+		for _, elem := range field {
+			err := validateString(key, value, fieldName, elem)
+			var valErr ValidationErrors
+			if errors.As(err, &valErr) {
+				validateErrors = append(validateErrors, valErr...)
+			} else {
+				valErr = append(valErr, ValidationError{
+					Field: fieldName,
+					Err:   err,
+				})
+			}
+
+		}
+	default:
+		validateErrors = append(validateErrors, ValidationError{
+			Field: fieldName,
+			Err:   ErrInterfaceConversion,
+		})
+	}
+	return validateErrors
+}
+
+// getValidationPair возвращает ключ-значение тэга `validate`
+//
+// 	Пример: len:32
+// 	key = len, value = 32
+func getValidationPair(cond string) (string, string, error) {
+	var keyValueSeparator = ":"
+	splitCond := strings.Split(cond, keyValueSeparator)
+	if len(splitCond) == 1 {
+		return "", "", ErrInvalidEmptyTag
+	} else if len(splitCond) == 2 && splitCond[1] == "" {
+		return "", "", ErrInvalidEmptyTag
+	}
+	key := splitCond[0]
+	value := splitCond[1]
+	return key, value, nil
 }

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -111,6 +111,10 @@ func Validate(v interface{}) error {
 				lock.Lock()
 				validationErrors = errHandler(err, validationErrors, field.Name)
 				lock.Unlock()
+			case reflect.Array, reflect.Bool, reflect.Chan, reflect.Complex128, reflect.Complex64,
+				reflect.Float32, reflect.Float64, reflect.Func, reflect.Interface, reflect.Invalid,
+				reflect.Map, reflect.Pointer, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Uint8, reflect.Uintptr, reflect.UnsafePointer:
 			default:
 				return
 			}

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -113,7 +113,7 @@ func Validate(v interface{}) error {
 				lock.Unlock()
 			case reflect.Array, reflect.Bool, reflect.Chan, reflect.Complex128, reflect.Complex64,
 				reflect.Float32, reflect.Float64, reflect.Func, reflect.Interface, reflect.Invalid,
-				reflect.Map, reflect.Pointer, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Map, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 				reflect.Uint8, reflect.Uintptr, reflect.UnsafePointer:
 			default:
 				return

--- a/hw09_struct_validator/validator_test.go
+++ b/hw09_struct_validator/validator_test.go
@@ -3,7 +3,10 @@ package hw09structvalidator
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type UserRole string
@@ -11,23 +14,26 @@ type UserRole string
 // Test the function on different structures and other types.
 type (
 	User struct {
-		ID     string `json:"id" validate:"len:36"`
-		Name   string
-		Age    int      `validate:"min:18|max:50"`
-		Email  string   `validate:"regexp:^\\w+@\\w+\\.\\w+$"`
-		Role   UserRole `validate:"in:admin,stuff"`
-		Phones []string `validate:"len:11"`
-		meta   json.RawMessage
+		ID          string `json:"id" validate:"len:36|regexp:\\d+"`
+		Name        string
+		Age         int      `validate:"min:18|max:50"`
+		Email       string   `validate:"regexp:^\\w+@\\w+\\.\\w+$"`
+		Role        UserRole `validate:"in:admin,stuff|regexp:\\W+"`
+		Phones      []string `validate:"len:11"`
+		meta        json.RawMessage
+		Application App `validate:"nested"`
 	}
 
 	App struct {
-		Version string `validate:"len:5"`
+		Version   string `validate:"len:5"`
+		UserToken Token  `validate:"nested"`
 	}
 
 	Token struct {
-		Header    []byte
-		Payload   []byte
-		Signature []byte
+		Header      []byte
+		Payload     []byte
+		Signature   []byte
+		GetResponse Response `validate:"nested"`
 	}
 
 	Response struct {
@@ -42,19 +48,171 @@ func TestValidate(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			// Place your code here.
+			in: User{
+				ID:     "rwerwer",
+				Name:   "sdfsdf",
+				Age:    12,
+				Email:  "324234",
+				Role:   "324234",
+				Phones: []string{"qewqeqweqweqwe", "qwertyuiop["},
+				meta:   []byte{},
+				Application: App{
+					Version: "123123123",
+					UserToken: Token{
+						Header:    []byte{},
+						Payload:   []byte{},
+						Signature: []byte{},
+						GetResponse: Response{
+							Code: 300,
+						},
+					},
+				},
+			},
+			expectedErr: ValidationErrors{
+				ValidationError{
+					Field: "ID",
+					Err:   ErrStringLength,
+				},
+				ValidationError{
+					Field: "ID",
+					Err:   ErrStringRegexp,
+				},
+				ValidationError{
+					Field: "Age",
+					Err:   ErrNumberMin,
+				},
+				ValidationError{
+					Field: "Email",
+					Err:   ErrStringRegexp,
+				},
+				ValidationError{
+					Field: "Role",
+					Err:   ErrStringIn,
+				},
+				ValidationError{
+					Field: "Role",
+					Err:   ErrStringRegexp,
+				},
+				ValidationError{
+					Field: "Phones",
+					Err:   ErrStringLength,
+				},
+				ValidationError{
+					Field: "Version",
+					Err:   ErrStringLength,
+				},
+				ValidationError{
+					Field: "Code",
+					Err:   ErrNumberIn,
+				},
+			},
 		},
-		// ...
-		// Place your code here.
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			tt := tt
 			t.Parallel()
+			err := Validate(tt.in)
+			var valErr ValidationErrors
+			require.ErrorAs(t, err, &valErr)
+			for _, error := range strings.Split(tt.expectedErr.Error(), "\n") {
+				require.ErrorContains(t, err, error)
+			}
 
-			// Place your code here.
-			_ = tt
 		})
 	}
+}
+func TestErrors(t *testing.T) {
+	t.Run("error ErrInterfaceType", func(t *testing.T) {
+		err := Validate("")
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrInterfaceType.Error())
+	})
+
+	t.Run("error ErrInvalidEmptyTag", func(t *testing.T) {
+		testStruct := struct {
+			Field1 string `validate:"len:"`
+		}{
+			"qwerty",
+		}
+
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrInvalidEmptyTag.Error())
+	})
+
+	t.Run("error ErrStringLength", func(t *testing.T) {
+		testStruct := struct {
+			Field1 string `validate:"len:1"`
+		}{
+			"qwerty",
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrStringLength.Error())
+	})
+
+	t.Run("error ErrStringRegexp", func(t *testing.T) {
+		testStruct := struct {
+			Field1 string `validate:"regexp:\\d+"`
+		}{
+			"qwerty",
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrStringRegexp.Error())
+	})
+
+	t.Run("error ErrStringIn", func(t *testing.T) {
+		testStruct := struct {
+			Field1 string `validate:"regexp:\\d+"`
+		}{
+			"qwerty",
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrStringRegexp.Error())
+	})
+
+	t.Run("error ErrNumberMax", func(t *testing.T) {
+		testStruct := struct {
+			Field1 int64 `validate:"max:0"`
+		}{
+			1,
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrNumberMax.Error())
+	})
+
+	t.Run("error ErrNumberMin", func(t *testing.T) {
+		testStruct := struct {
+			Field1 int64 `validate:"min:0"`
+		}{
+			-1,
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrNumberMin.Error())
+	})
+
+	t.Run("error ErrNumberIn", func(t *testing.T) {
+		testStruct := struct {
+			Field1 int64 `validate:"in:0"`
+		}{
+			-1,
+		}
+		err := Validate(testStruct)
+		var valErr ValidationErrors
+		require.ErrorAs(t, err, &valErr)
+		require.ErrorContains(t, valErr, ErrNumberMin.Error())
+	})
 }

--- a/hw09_struct_validator/validator_test.go
+++ b/hw09_struct_validator/validator_test.go
@@ -42,6 +42,7 @@ type (
 	}
 )
 
+// TestValidate проверка работоспособности.
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		in          interface{}
@@ -119,10 +120,10 @@ func TestValidate(t *testing.T) {
 			for _, error := range strings.Split(tt.expectedErr.Error(), "\n") {
 				require.ErrorContains(t, err, error)
 			}
-
 		})
 	}
 }
+
 func TestErrors(t *testing.T) {
 	t.Run("error ErrInterfaceType", func(t *testing.T) {
 		err := Validate("")
@@ -213,6 +214,6 @@ func TestErrors(t *testing.T) {
 		err := Validate(testStruct)
 		var valErr ValidationErrors
 		require.ErrorAs(t, err, &valErr)
-		require.ErrorContains(t, valErr, ErrNumberMin.Error())
+		require.ErrorContains(t, valErr, ErrNumberIn.Error())
 	})
 }


### PR DESCRIPTION
## Домашнее задание №9 «Валидатор структур»

Необходимо реализовать функцию:
```golang
func Validate(v interface{}) error
```
Она должна валидировать публичные поля входной структуры на основе структурного тэга `validate`.

Функция может возвращать
- или программную ошибку, произошедшую во время валидации;
- или `ValidationErrors` - ошибку, являющуюся слайсом структур, содержащих имя поля и ошибку его валидации.

Таким образом, нужно накопить все ошибки валидации, а не прерывать валидацию на первой ошибке.

Если у поля нет структурных тэгов или нет тэга `validate`, то функция игнорирует его.

Типы полей, которые обязательно должны поддерживаться:
- `int`, `[]int`;
- `string`, `[]string`.

_При желании можно дополнительно поддержать любые другие типы (на ваше усмотрение)._

Необходимо реализовать следующие валидаторы:
- Для строк:
    * `len:32` - длина строки должна быть ровно 32 символа;
    * `regexp:\\d+` - согласно регулярному выражению строка должна состоять из цифр
    (`\\` - экранирование слэша);
    * `in:foo,bar` - строка должна входить в множество строк {"foo", "bar"}.
- Для чисел:
    * `min:10` - число не может быть меньше 10;
    * `max:20` - число не может быть больше 20;
    * `in:256,1024` - число должно входить в множество чисел {256, 1024};
- Для слайсов валидируется каждый элемент слайса.

_При желании можно дополнительно добавить парочку новых правил (на ваше усмотрение)._

Допускается комбинация валидаторов по логическому "И" с помощью `|`, например:
* `min:0|max:10` - число должно находится в пределах [0, 10];
* `regexp:\\d+|len:20` - строка должна состоять из цифр и иметь длину 20.

**(\*) Дополнительное задание: поддержка валидации вложенных по композиции структур.**
```golang
type User struct {
    m Meta `validate:"nested"`
}
```

### Критерии оценки
- Пайплайн зелёный - 3 балла
- Добавлены юнит-тесты - до 4 баллов
- Понятность и чистота кода - до 3 баллов
- Дополнительное задание на баллы не влияет

#### Зачёт от 7 баллов

### Подсказки
- `reflect.StructTag`
- `regexp.Compile`
- `errors.Is`

### Частые ошибки
- Отсутствует проверка на то, что входной `interface{}` - структура.
- Нет разделения на программные ошибки (неверный тэг, регулярка и пр.) и ошибки валидации.
- Ошибки валидации не вынесены в отдельные переменные и не завраплены.
- Соответственно в тестах не используется `errors.Is` / `errors.As`.
